### PR TITLE
Updated module to python 3.10 standards

### DIFF
--- a/mevolib/align/_Mafft.py
+++ b/mevolib/align/_Mafft.py
@@ -1,46 +1,26 @@
-#-------------------------------------------------------------------------------
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 #
-#   MEvoLib  Copyright (C) 2016  J. Alvarez-Jarreta
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#   This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-#   This is free software, and you are welcome to redistribute it under certain
-#   conditions; type `show c' for details.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-#-------------------------------------------------------------------------------
-# File :  _Mafft.py
-# Last version :  v1.01 ( 01/Feb/2016 )
-# Description :  MEvoLib's variables to ease the usage of Mafft.
-#-------------------------------------------------------------------------------
-# Historical report :
-#
-#   DATE :  01/Feb/2016
-#   VERSION :  v1.01
-#   AUTHOR(s) :  J. Alvarez-Jarreta
-#   CHANGES :  * The "-1" option for "--thread" argument doesn't work as
-#                  expected, so we now include explicitly the number of cores.
-#
-#   DATE :  13/Jan/2016
-#   VERSION :  v1.00
-#   AUTHOR(s) :  J. Alvarez-Jarreta
-#
-#-------------------------------------------------------------------------------
-
-from __future__ import absolute_import
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MEvoLib's variables to ease the usage of Mafft."""
 
 from mevolib._utils import NUMCORES
 
 
-#-------------------------------------------------------------------------------
-
 SPRT_INFILE_FORMATS = ['fasta']
-
 INFILE_CMD = ''
-
-KEYWORDS = { 'default':  ['--auto', '--quiet', '--thread', str(NUMCORES)],
-             'linsi':    ['--localpair', '--maxiterate', '1000', '--quiet',
-                          '--thread', str(NUMCORES)],
-             'parttree': ['--parttree', '--retree', '2', '--partsize', '1000',
-                          '--quiet', '--thread', str(NUMCORES)] }
-
-
-#-------------------------------------------------------------------------------
+KEYWORDS = {
+    'default': ['--auto', '--quiet', '--thread', str(NUMCORES)],
+    'linsi': ['--localpair', '--maxiterate', '1000', '--quiet', '--thread', str(NUMCORES)],
+    'parttree': ['--parttree', '--retree', '2', '--partsize', '1000', '--quiet', '--thread', str(NUMCORES)],
+}

--- a/mevolib/align/__init__.py
+++ b/mevolib/align/__init__.py
@@ -1,139 +1,88 @@
-#-------------------------------------------------------------------------------
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 #
-#   MEvoLib  Copyright (C) 2016  J. Alvarez-Jarreta
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#   This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-#   This is free software, and you are welcome to redistribute it under certain
-#   conditions; type `show c' for details.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-#-------------------------------------------------------------------------------
-# File :  __init__.py
-# Last version :  v1.10 ( 16/Jul/2016 )
-# Description :  Functions aimed to provide an easy interface to handle
-#       different alignment tools.
-#-------------------------------------------------------------------------------
-# Historical report :
-#
-#   DATE :  16/Jul/2016
-#   VERSION :  v1.10
-#   AUTHOR(s) :  J. Alvarez-Jarreta
-#   CHANGES :  * Added get_tools() method to have an easy access to all the
-#                  available alignment tools.
-#
-#   DATE :  26/Jan/2016
-#   VERSION :  v1.00
-#   AUTHOR(s) :  J. Alvarez-Jarreta
-#
-#-------------------------------------------------------------------------------
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions aimed to provide an easy interface to handle different alignment tools."""
 
-from __future__ import absolute_import
-
+from io import StringIO
 import os
 import tempfile
+from typing import Optional
 import subprocess
 
 from Bio import SeqIO, AlignIO
 
-from . import _ClustalOmega
-from . import _Mafft
-from . import _Muscle
-
+from mevolib.align import _ClustalOmega, _Mafft, _Muscle
 from mevolib._utils import get_abspath
-from mevolib._py3k import viewkeys, viewitems, DEVNULL, StringIO
 
 
-#-------------------------------------------------------------------------------
-
-_TOOL_TO_LIB = { 'clustalo': _ClustalOmega,
-                 'mafft': _Mafft,
-                 'muscle': _Muscle }
-
-
-#-------------------------------------------------------------------------------
-
-def get_tools ( ) :
-    """
-    Returns :
-        list
-            List of alignment software tools included in the current version of
-            MEvoLib.
-    """
-    return ( list(viewkeys(_TOOL_TO_LIB)) )
+_TOOL_TO_LIB = {
+    'clustalo': _ClustalOmega,
+    'mafft': _Mafft,
+    'muscle': _Muscle,
+}
 
 
+def get_tools() -> list:
+    """Returns a list of alignment software tools included in the current version of MEvoLib."""
+    return list(_TOOL_TO_LIB.keys())
 
-def get_keywords ( tool ) :
-    """
-    Arguments :
-        tool  ( string )
-            Name of the alignment tool.
 
-    Returns :
-        dict
-            Dictionary containing the keywords and their corresponding
-            arguments.
+def get_keywords(tool: str) -> dict:
+    """Returns a dictionary containing the keywords and their corresponding arguments.
 
-    Raises :
-        ValueError
-            If the tool introduced isn't included in MEvoLib.Align.
+    Args:
+        tool: Name of the alignment tool.
+
+    Raises:
+        ValueError: If the tool introduced is not included in `mevolib.align`.
+
     """
     tool = tool.lower()
-    if ( tool not in _TOOL_TO_LIB ) :
-        message = 'The alignment tool "{}" isn\'t included in ' \
-                  'MEvoLib.Align'.format(tool)
-        raise ValueError(message)
-    # else : # tool in _TOOL_TO_LIB
+    if tool not in _TOOL_TO_LIB:
+        raise ValueError(f'The alignment tool "{tool}" is not included in MEvoLib.Align')
     keyword_dict = {}
-    for key, value in iter(viewitems(_TOOL_TO_LIB[tool].KEYWORDS)) :
+    for key, value in _TOOL_TO_LIB[tool].KEYWORDS.items():
         keyword_dict[key] = ' '.join(value)
-    return ( keyword_dict )
-        
+    return keyword_dict
 
 
-def get_alignment ( binary, infile, infile_format, args = 'default',
-                    outfile = None, outfile_format = 'fasta', **kwargs ) :
-    """
-    Align the sequences of the input file using the alignment tool and arguments
-    given. The resultant alignment is returned as a Bio.Align.MultipleSeqAlign
-    object and saved in the ouput file (if provided). If 'infile' or 'outfile'
-    contain a relative path, the current working directory will be used to get
-    the absolute path. If the output file already exists, the old file will be
+def get_alignment(binary: str, infile: str, infile_format: str, args: str = 'default',
+                  outfile: Optional[str] = None, outfile_format: str = 'fasta',
+                  **kwargs: dict) -> Bio.Align.MultipleSeqAlignment:
+    """Returns the result of aligning the sequences using the given alignment tool and arguments.
+
+    The resultant alignment is returned as a Bio.Align.MultipleSeqAlign object and saved in the output
+    file (if provided). If `infile` or `outfile` contain a relative path, the current working directory
+    will be used to get the absolute path. If the output file already exists, the old file will be
     overwritten without any warning.
 
-    The alignment tool might not be included in MEvoLib, but it can still be
-    used passing in '**kwargs' the keys "informats" and "incmd" with the list of
-    of supported infile formats and the infile argument, respectively.
+    The alignment tool might not be included in MEvoLib, but it can still be used passing in `**kwargs`
+    the keys "informats" and "incmd" with the list of supported infile formats and the infile argument
+    (empty string if it does not need any), respectively.
 
-    Arguments :
-        binary  ( string )
-            Name or path of the alignment tool.
-        infile  ( string )
-            Unaligned input sequence file.
-        infile_format  ( string )
-            Input file format.
-        args  ( Optional[string] )
-            Keyword or arguments to use in the call of the aligment tool,
-            excluding infile and outfile arguments.  By default, 'default'
-            arguments are used.
-        outfile  ( Optional[string] )
-            Alignment output file.
-        outfile_format  ( Optional[string] )
-            Output file format. By default, FASTA format.
-        **kwargs  ( Optional[dict] )
-            Keyworded arguments required to execute alignment tools not included
-            in the current version of MEvoLib. It is neccesary to pass a list
-            of supported infile formats under "informats" key, and the infile
-            argument (e.g. "-in") with "incmd" key.
+    Args:
+        binary: Name or path of the alignment tool.
+        infile: Unaligned input sequence file.
+        infile_format: Input file format.
+        args: Keyword or arguments to use in the call of the alignment tool, excluding infile and
+            outfile arguments. By default, "default" arguments are used.
+        outfile: Alignment output file.
+        outfile_format: Output file format. By default, FASTA format.
 
-    Returns :
-        Bio.Align.MultipleSeqAlignment
-            Resultant alignment.
-
-    Raises :
-        IOError
-            If the input path or the input file provided doesn't exist.
-        RuntimeError
-            If the call to the alignment tool command raises an exception.
+    Raises:
+        IOError: If the input path or the input file provided does not exist.
+        RuntimeError: If the call to the alignment tool command raises an exception.
 
     * The input file format must be supported by Bio.SeqIO.
     * The output file format must be supported by Bio.AlignIO.
@@ -142,49 +91,43 @@ def get_alignment ( binary, infile, infile_format, args = 'default',
     # values from **kwargs
     bin_path, bin_name = os.path.split(binary)
     bin_name = bin_name.lower()
-    if ( bin_name in _TOOL_TO_LIB ) :
+    if bin_name in _TOOL_TO_LIB:
         tool_lib = _TOOL_TO_LIB[bin_name]
         sprt_infile_formats = tool_lib.SPRT_INFILE_FORMATS
         infile_cmd = tool_lib.INFILE_CMD
         keywords = tool_lib.KEYWORDS
-    else : # bin_name not in _TOOL_TO_LIB
+    else:
         # Include the required variables through **kwargs dictionary
         sprt_infile_formats = kwargs['informats']
         infile_cmd = kwargs['incmd']
         keywords = dict()
     # Get the command line to run in order to get the resultant alignment
     infile_path = get_abspath(infile)
-    # If the input file format is not supported by the alignment tool, convert
-    # it to a temporary supported file
-    if ( infile_format.lower() not in sprt_infile_formats ) :
+    # If the input file format is not supported by the alignment tool, convert it to a temporary
+    # supported file
+    if infile_format.lower() not in sprt_infile_formats:
         tmpfile = tempfile.NamedTemporaryFile()
-        SeqIO.convert(infile_path, infile_format, tmpfile.name,
-                      sprt_infile_formats[0])
+        SeqIO.convert(infile_path, infile_format, tmpfile.name, sprt_infile_formats[0])
         infile_path = tmpfile.name
     # Get argument list from keyword dictionary or 'args' string
-    if ( args in keywords ) :
+    if args in keywords:
         arg_list = keywords[args]
-    else : # args not in keywords
+    else:
         # Remove possible empty strings in the given arguments
-        arg_list = [arg  for arg in args.split(' ')]
+        arg_list = [arg for arg in args.split(' ')]
     # Create full command line list (removing empty elements)
-    command = [x  for x in [binary] + arg_list + [infile_cmd, infile_path] if x]
+    command = [x for x in [binary] + arg_list + [infile_cmd, infile_path] if x]
     # Run the alignment process handling any Runtime exception
-    try :
-        output = subprocess.check_output(command, stderr=DEVNULL,
-                                         universal_newlines=True)
-    except subprocess.CalledProcessError as e :
-        message = 'Running "{}" raised an exception'.format(' '.join(e.cmd))
-        raise RuntimeError(message)
-    else :
+    try:
+        output = subprocess.run(command, stderr=subprocess.DEVNULL, universal_newlines=True, check=True,
+                                stdout=subprocess.PIPE).stdout
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f'Running "{' '.join(e.cmd)}" raised an exception')
+    else:
         alignment = AlignIO.read(StringIO(output), 'fasta')
-        if ( outfile ) :
+        if outfile:
             # Save the resultant alignment in the given outfile and format
             outfile_path = get_abspath(outfile)
             AlignIO.write(alignment, outfile_path, outfile_format)
-        # Return the resultant alignment as a Bio.Align.MultipleSeqAligment
-        # object
-        return ( alignment )
-
-
-#-------------------------------------------------------------------------------
+        # Return the resultant alignment as a Bio.Align.MultipleSeqAligment object
+        return alignment


### PR DESCRIPTION
Updated `mevolib.align.__init__.py` and `mevolib.align.Mafft.py` to Python 3.10 standards.