### PR TITLE
Add partial support to Muscle

### DIFF
--- a/mevolib/align/_Muscle.py
+++ b/mevolib/align/_Muscle.py
@@ -16,11 +16,8 @@
 
 SPRT_INFILE_FORMATS = ["fasta"]
 
-INFILE_CMD = "-in"
+INFILE_CMD = "-align"
 
 KEYWORDS = {
-    "default": ["-quiet"],
-    "fastdna": ["-maxiters", "1", "-diags", "-quiet"],
-    "fastprot": ["-maxiters", "1", "-diags", "-sv", "-distance1", "kbit20_3", "-quiet"],
-    "largein": ["-maxiters", "2", "-quiet"],
+    "default": ["-output /dev/stdout"],
 }


### PR DESCRIPTION
I have used the trick to pass `/dev/stdout` to the mandatory `-output` argument to try to provide certain degree of compatibility. However, the current setup of `mevolib.align` will not work out of the box for this tool in any other case.

Happy to drop `Muscle.py` instead if you believe partial support is not a great mid-step (and add it back once the module is improved).